### PR TITLE
Add option to align labels on the right + ability to disable tree drawing 

### DIFF
--- a/lib/.eslintrc.json
+++ b/lib/.eslintrc.json
@@ -6,7 +6,8 @@
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
-    "plugin:@typescript-eslint/recommended"
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react-hooks/recommended"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {

--- a/lib/src/components/MSACanvas.tsx
+++ b/lib/src/components/MSACanvas.tsx
@@ -39,7 +39,7 @@ const MSABlock = observer(
           letter,
           theme.palette.getContrastText(Color(color).hex()),
         ]),
-      [colorScheme],
+      [colorScheme, theme.palette],
     )
     const ref = useRef<HTMLCanvasElement>(null)
     useEffect(() => {

--- a/lib/src/components/MSAView.tsx
+++ b/lib/src/components/MSAView.tsx
@@ -34,7 +34,7 @@ export default observer(({ model }: { model: MsaViewModel }) => {
       }
     }
     return () => {}
-  }, [cropMouseDown])
+  }, [cropMouseDown, model])
 
   if (!initialized) {
     return <ImportForm model={model} />

--- a/lib/src/components/SettingsDlg.tsx
+++ b/lib/src/components/SettingsDlg.tsx
@@ -85,6 +85,15 @@ export default observer(
             }
             label="Draw tree (if available)"
           />
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={model.labelsAlignRight}
+                onChange={() => model.toggleLabelsAlignRight()}
+              />
+            }
+            label="Labels align right"
+          />
 
           <TextField
             label="Row height (px)"

--- a/lib/src/components/SettingsDlg.tsx
+++ b/lib/src/components/SettingsDlg.tsx
@@ -76,6 +76,15 @@ export default observer(
             }
             label="Draw node bubbles"
           />
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={model.drawTree}
+                onChange={() => model.toggleDrawTree()}
+              />
+            }
+            label="Draw tree (if available)"
+          />
 
           <TextField
             label="Row height (px)"

--- a/lib/src/components/SettingsDlg.tsx
+++ b/lib/src/components/SettingsDlg.tsx
@@ -92,7 +92,7 @@ export default observer(
                 onChange={() => model.toggleLabelsAlignRight()}
               />
             }
-            label="Labels align right"
+            label="Labels align right (note: labels may draw over tree, but can adjust tree width or tree area width in UI)"
           />
 
           <TextField

--- a/lib/src/components/TreeCanvas.tsx
+++ b/lib/src/components/TreeCanvas.tsx
@@ -44,6 +44,8 @@ const TreeBlock = observer(
       noTree,
       blockSize,
       drawNodeBubbles,
+      drawTree,
+      treeAreaWidth,
     } = model
 
     useEffect(() => {
@@ -65,7 +67,7 @@ const TreeBlock = observer(
       const font = ctx.font
       ctx.font = font.replace(/\d+px/, `${Math.max(8, rowHeight - 8)}px`)
 
-      if (!noTree) {
+      if (!noTree && drawTree) {
         hierarchy.links().forEach(({ source, target }) => {
           const y = showBranchLen ? 'len' : 'y'
           //@ts-ignore
@@ -126,6 +128,9 @@ const TreeBlock = observer(
 
         if (labelsAlignRight) {
           ctx.textAlign = 'end'
+          ctx.setLineDash([3, 5])
+        } else {
+          ctx.textAlign = 'start'
         }
         hierarchy.leaves().forEach((node) => {
           const {
@@ -142,9 +147,24 @@ const TreeBlock = observer(
             y < offsetY + blockSize + extendBounds
           ) {
             //note: +rowHeight/4 matches with -rowHeight/4 in msa
-            ctx.fillText(name, (showBranchLen ? len : x) + d, y + rowHeight / 4)
+            const yp = y + rowHeight / 4
+            const xp = showBranchLen ? len : x
+            if (!drawTree && !labelsAlignRight) {
+              ctx.fillText(name, 0, yp)
+            } else if (labelsAlignRight) {
+              if (drawTree) {
+                const { width } = ctx.measureText(name)
+                ctx.moveTo(xp + radius + 2, y)
+                ctx.lineTo(treeAreaWidth - 30 - width, y)
+                ctx.stroke()
+              }
+              ctx.fillText(name, treeAreaWidth - 30, yp)
+            } else {
+              ctx.fillText(name, xp + d, yp)
+            }
           }
         })
+        ctx.setLineDash([])
       }
       setColorMap(colorHash)
     }, [
@@ -158,7 +178,9 @@ const TreeBlock = observer(
       noTree,
       blockSize,
       drawNodeBubbles,
+      drawTree,
       labelsAlignRight,
+      treeAreaWidth,
     ])
 
     function decode(event: React.MouseEvent) {

--- a/lib/src/components/TreeCanvas.tsx
+++ b/lib/src/components/TreeCanvas.tsx
@@ -40,6 +40,7 @@ const TreeBlock = observer(
       showBranchLen,
       collapsed,
       margin,
+      labelsAlignRight,
       noTree,
       blockSize,
       drawNodeBubbles,
@@ -122,6 +123,10 @@ const TreeBlock = observer(
 
       if (rowHeight >= 10) {
         ctx.fillStyle = 'black'
+
+        if (labelsAlignRight) {
+          ctx.textAlign = 'end'
+        }
         hierarchy.leaves().forEach((node) => {
           const {
             //@ts-ignore
@@ -153,6 +158,7 @@ const TreeBlock = observer(
       noTree,
       blockSize,
       drawNodeBubbles,
+      labelsAlignRight,
     ])
 
     function decode(event: React.MouseEvent) {

--- a/lib/src/model.ts
+++ b/lib/src/model.ts
@@ -77,8 +77,8 @@ const model = types.snapshotProcessor(
           colWidth: 16,
           showBranchLen: true,
           bgColor: true,
+          drawTree: false,
           drawNodeBubbles: true,
-          dragHandleType: 'crop',
           colorSchemeName: 'maeditor',
           treeFilehandle: types.maybe(FileLocation),
           msaFilehandle: types.maybe(FileLocation),
@@ -141,8 +141,8 @@ const model = types.snapshotProcessor(
           setCurrentAlignment(n: number) {
             self.currentAlignment = n
           },
-          setDragHandleType(str: string) {
-            self.dragHandleType = str
+          toggleDrawTree() {
+            self.drawTree = !self.drawTree
           },
           toggleCollapsed(node: string) {
             if (self.collapsed.includes(node)) {
@@ -337,6 +337,16 @@ const model = types.snapshotProcessor(
                 ? generateNodeIds(parseNewick(tree))
                 : this.MSA?.getTree()
 
+              if (!self.drawTree) {
+                return {
+                  id: 'root',
+                  noTree: true,
+                  branchset: this.MSA?.getNames().map((name) => ({
+                    id: name,
+                    name,
+                  })),
+                }
+              }
               return t ? filter(t, collapsed) : { noTree: true }
             },
 

--- a/lib/src/model.ts
+++ b/lib/src/model.ts
@@ -78,7 +78,7 @@ const model = types.snapshotProcessor(
           colWidth: 16,
           showBranchLen: true,
           bgColor: true,
-          drawTree: false,
+          drawTree: true,
           drawNodeBubbles: true,
           colorSchemeName: 'maeditor',
           treeFilehandle: types.maybe(FileLocation),
@@ -341,21 +341,13 @@ const model = types.snapshotProcessor(
                 ? generateNodeIds(parseNewick(tree))
                 : this.MSA?.getTree()
 
-              if (!self.drawTree) {
-                return {
-                  id: 'root',
-                  noTree: true,
-                  branchset: this.MSA?.getNames().map((name) => ({
-                    id: name,
-                    name,
-                  })),
-                }
-              }
               return t ? filter(t, collapsed) : { noTree: true }
             },
 
-            get rowNames() {
-              return this.hierarchy.leaves().map((node) => node.data.name)
+            get rowNames(): string[] {
+              return this.hierarchy
+                .leaves()
+                .map((node: { data: { name: string } }) => node.data.name)
             },
 
             get mouseOverRowName() {

--- a/lib/src/model.ts
+++ b/lib/src/model.ts
@@ -74,6 +74,7 @@ const model = types.snapshotProcessor(
           blockSize: 1000,
           mouseRow: types.maybe(types.number),
           mouseCol: types.maybe(types.number),
+          labelsAlignRight: false,
           colWidth: 16,
           showBranchLen: true,
           bgColor: true,
@@ -140,6 +141,9 @@ const model = types.snapshotProcessor(
           },
           setCurrentAlignment(n: number) {
             self.currentAlignment = n
+          },
+          toggleLabelsAlignRight() {
+            self.labelsAlignRight = !self.labelsAlignRight
           },
           toggleDrawTree() {
             self.drawTree = !self.drawTree

--- a/lib/src/parsers/ClustalMSA.ts
+++ b/lib/src/parsers/ClustalMSA.ts
@@ -25,6 +25,10 @@ export default class ClustalMSA {
     return this.MSA.header
   }
 
+  getNames() {
+    return this.MSA.alns.map((aln) => aln.id)
+  }
+
   get alignmentNames() {
     return []
   }
@@ -33,7 +37,7 @@ export default class ClustalMSA {
     return {
       id: 'root',
       noTree: true,
-      branchset: this.MSA.alns.map((aln) => ({ id: aln.id, name: aln.id })),
+      branchset: this.getNames().map((name) => ({ id: name, name })),
     }
   }
 }

--- a/lib/src/parsers/FastaMSA.ts
+++ b/lib/src/parsers/FastaMSA.ts
@@ -20,6 +20,10 @@ export default class FastaMSA {
     return this.MSA
   }
 
+  getNames() {
+    return Object.keys(this.MSA.seqdata)
+  }
+
   getRow(name: string) {
     return this.MSA?.seqdata[name]?.split('')
   }
@@ -41,7 +45,7 @@ export default class FastaMSA {
     return {
       id: 'root',
       noTree: true,
-      branchset: Object.keys(this.MSA.seqdata).map((name) => ({
+      branchset: this.getNames().map((name) => ({
         id: name,
         name,
       })),

--- a/lib/src/parsers/StockholmMSA.ts
+++ b/lib/src/parsers/StockholmMSA.ts
@@ -43,6 +43,10 @@ export default class StockholmMSA {
     return this.MSA.gf
   }
 
+  getNames() {
+    return Object.keys(this.MSA.seqdata)
+  }
+
   getTree() {
     const tree = this.MSA?.gf?.NH?.[0]
     return tree
@@ -50,7 +54,7 @@ export default class StockholmMSA {
       : {
           id: 'root',
           noTree: true,
-          branchset: Object.keys(this.MSA.seqdata).map((name) => ({
+          branchset: this.getNames().map((name) => ({
             id: name,
             name,
           })),


### PR DESCRIPTION
In some cases, the tree may be too much info, so we give the option to disable drawing it even if it is available

Additionally, we allow aligning the node labels on the right of the screen, making it easier to line it up with the msa row in some cases

Note that there is a mouseover action that says which row you are mousing over which helps in this case too, but for a screenshot it may be nicer

This is similar to abrowse with it's right aligned labels

![Screenshot from 2021-06-05 01-50-02](https://user-images.githubusercontent.com/6511937/120881613-63848300-c5a0-11eb-839d-7f24af95a03d.png)
