### PR TITLE
New clickmap that allows all nodes in the treemap to be clicked

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -60,6 +60,7 @@
     "d3-array": "^2.12.0",
     "d3-hierarchy": "^2.0.0",
     "normalize-wheel": "^1.0.1",
+    "rbush": "^3.0.1",
     "stockholm-js": "^1.0.10"
   }
 }

--- a/lib/src/components/TreeCanvas.tsx
+++ b/lib/src/components/TreeCanvas.tsx
@@ -19,14 +19,23 @@ interface TooltipData {
   y: number
 }
 
+interface ClickEntry {
+  name: string
+  id: string
+  branch?: boolean
+  minX: number
+  maxX: number
+  minY: number
+  maxY: number
+}
 const TreeBlock = observer(
   ({ model, offsetY }: { model: MsaViewModel; offsetY: number }) => {
     const ref = useRef<HTMLCanvasElement>(null)
-    const clickMap = useRef(new RBush())
+    const clickMap = useRef(new RBush<ClickEntry>())
     const mouseoverRef = useRef<HTMLCanvasElement>(null)
     const [branchMenu, setBranchMenu] = useState<TooltipData>()
     const [toggleNodeMenu, setToggleNodeMenu] = useState<TooltipData>()
-    const [hoverElt, setHoverElt] = useState<any>()
+    const [hoverElt, setHoverElt] = useState<ClickEntry>()
 
     const {
       hierarchy,

--- a/lib/src/components/TreeCanvas.tsx
+++ b/lib/src/components/TreeCanvas.tsx
@@ -35,8 +35,6 @@ const TreeBlock = observer(
     const collapseBranchMenuRef = useRef<HTMLDivElement>(null)
     const toggleNodeMenuRef = useRef<HTMLDivElement>(null)
     const mouseoverRef = useRef<HTMLCanvasElement>(null)
-    const [collapsedClickMap, setCollapsedClickMap] = useState<ClickMap>({})
-    const [nameClickMap, setNameClickMap] = useState<ClickMap>({})
     const [collapseBranchMenu, setCollapseBranchMenu] = useState<TooltipData>()
     const [toggleNodeMenu, setToggleNodeMenu] = useState<TooltipData>()
     const [hoverElt, setHoverElt] = useState<any>()
@@ -205,8 +203,6 @@ const TreeBlock = observer(
         })
         ctx.setLineDash([])
       }
-      setCollapsedClickMap(tempCollapsedClickMap)
-      setNameClickMap(tempNameClickMap)
     }, [
       collapsed,
       rowHeight,

--- a/lib/src/model.ts
+++ b/lib/src/model.ts
@@ -5,7 +5,6 @@ import { FileLocation, ElementId } from '@jbrowse/core/util/types/mst'
 import { FileLocation as FileLocationType } from '@jbrowse/core/util/types'
 import { openLocation } from '@jbrowse/core/util/io'
 import { autorun } from 'mobx'
-import Color from 'color'
 import BaseViewModel from '@jbrowse/core/pluggableElementTypes/models/BaseViewModel'
 
 import Stockholm from 'stockholm-js'
@@ -15,7 +14,7 @@ import FastaMSA from './parsers/FastaMSA'
 import parseNewick from './parseNewick'
 import colorSchemes from './colorSchemes'
 
-import { generateNodeIds, transform, NodeWithIds } from './util'
+import { generateNodeIds, NodeWithIds } from './util'
 import AnnotationTrack from './components/Annotations'
 
 function setBrLength(d: HierarchyNode<any>, y0: number, k: number) {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.170",
+    "@types/rbush": "^3.0.0",
     "concurrently": "^6.2.0",
     "serve": "^11.3.2",
     "wait-on": "^5.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11309,6 +11309,11 @@ quick-lru@^2.0.0:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-2.0.0.tgz#32b017b28d1784631c8ab0a1ed2978e094dbe181"
   integrity sha512-DqOtZziv7lDjEyuqyVQacRciAwMCEjTNrLYCHYEIIgjcE/tLEpBF82hiDIwCjRnEL9/hY2GJxA0T8ZvYvVVSSA==
 
+quickselect@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/quickselect/-/quickselect-2.0.0.tgz#f19680a486a5eefb581303e023e98faaf25dd018"
+  integrity sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==
+
 raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
@@ -11350,6 +11355,13 @@ raw-body@2.4.0:
     http-errors "1.7.2"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+rbush@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/rbush/-/rbush-3.0.1.tgz#5fafa8a79b3b9afdfe5008403a720cc1de882ecf"
+  integrity sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==
+  dependencies:
+    quickselect "^2.0.0"
 
 rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
   version "1.2.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2292,6 +2292,11 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
+"@types/rbush@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/rbush/-/rbush-3.0.0.tgz#b6887d99b159e87ae23cd14eceff34f139842aa6"
+  integrity sha512-W3ue/GYWXBOpkRm0VSoifrP3HV0Ni47aVJWvXyWMcbtpBy/l/K/smBRiJ+fI8f7shXRjZBiux+iJzYbh7VmcZg==
+
 "@types/react-dom@^17.0.0":
   version "17.0.7"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.7.tgz#b8ee15ead9e5d6c2c858b44949fdf2ebe5212232"


### PR DESCRIPTION
To try to help goals of displaying annotation, I wanted to make sure every row in the tree could be clicked in order to try to fetch annotations for each row

The "click map" was getting a bit unwieldy so I switched the implementation up

It is still pretty complex because we aren't just rendering html elements with onclick, they are canvas elements that need manual click handlers