### PR TITLE
Allow hiding leaf node

### DIFF
--- a/lib/src/components/TreePanel/TreeNodeMenu.tsx
+++ b/lib/src/components/TreePanel/TreeNodeMenu.tsx
@@ -5,6 +5,7 @@ import { observer } from 'mobx-react'
 // locals
 import { MsaViewModel } from '../../model'
 
+// lazies
 const TreeNodeInfoDialog = lazy(() => import('./dialogs/TreeNodeInfoDialog'))
 
 const TreeMenu = observer(function ({
@@ -16,104 +17,102 @@ const TreeMenu = observer(function ({
   model: MsaViewModel
   onClose: () => void
 }) {
-  const { structures } = model
+  const { selectedStructures, collapsed, structures } = model
   const nodeDetails = node ? model.getRowData(node.name) : undefined
 
   return (
-    <>
-      <Menu
-        anchorReference="anchorPosition"
-        anchorPosition={{
-          top: node.y,
-          left: node.x,
+    <Menu
+      anchorReference="anchorPosition"
+      anchorPosition={{
+        top: node.y,
+        left: node.x,
+      }}
+      transitionDuration={0}
+      keepMounted
+      open={Boolean(node)}
+      onClose={onClose}
+    >
+      <MenuItem dense disabled>
+        {node.name}
+      </MenuItem>
+
+      <MenuItem
+        dense
+        onClick={() => {
+          model.queueDialog(onClose => [
+            TreeNodeInfoDialog,
+            {
+              info: model.getRowData(node.name),
+              model,
+              nodeName: node.name,
+              onClose,
+            },
+          ])
+          onClose()
         }}
-        transitionDuration={0}
-        keepMounted
-        open={Boolean(node)}
-        onClose={onClose}
       >
-        <MenuItem dense disabled>
-          {node.name}
-        </MenuItem>
+        More info...
+      </MenuItem>
+      <MenuItem
+        dense
+        onClick={() => {
+          model.toggleCollapsed(node.id)
+          onClose()
+        }}
+      >
+        {collapsed.includes(node.id) ? 'Show node' : 'Hide node'}
+      </MenuItem>
 
-        <MenuItem
-          dense
-          onClick={() => {
-            model.queueDialog(onClose => [
-              TreeNodeInfoDialog,
-              {
-                info: model.getRowData(node.name),
-                model,
-                nodeName: node.name,
-                onClose,
-              },
-            ])
-            onClose()
-          }}
-        >
-          More info...
-        </MenuItem>
-        <MenuItem
-          dense
-          onClick={() => {
-            model.hideNode(node.id)
-            onClose()
-          }}
-        >
-          Hide node
-        </MenuItem>
-
-        {structures[node.name]?.map(entry => {
-          return !model.selectedStructures.some(n => n.id === node.name) ? (
-            <MenuItem
-              key={JSON.stringify(entry)}
-              dense
-              onClick={() => {
-                model.addStructureToSelection({
-                  structure: entry,
-                  id: node.name,
-                })
-                onClose()
-              }}
-            >
-              Add PDB to selection ({entry.pdb})
-            </MenuItem>
-          ) : (
-            <MenuItem
-              key={JSON.stringify(entry)}
-              dense
-              onClick={() => {
-                model.removeStructureFromSelection({
-                  structure: entry,
-                  id: node.name,
-                })
-                onClose()
-              }}
-            >
-              Remove PDB from selection ({entry.pdb})
-            </MenuItem>
-          )
-        })}
-
-        {// @ts-expect-error
-        nodeDetails?.data.accession?.map(accession => (
+      {structures[node.name]?.map(entry =>
+        !selectedStructures.some(n => n.id === node.name) ? (
           <MenuItem
+            key={JSON.stringify(entry)}
             dense
-            key={accession}
             onClick={() => {
-              model.addUniprotTrack({
-                // @ts-expect-error
-                name: nodeDetails?.data.name,
-                accession,
+              model.addStructureToSelection({
+                structure: entry,
+                id: node.name,
               })
               onClose()
             }}
           >
-            Open UniProt track ({accession})
+            Add PDB to selection ({entry.pdb})
           </MenuItem>
-        ))}
-      </Menu>
-    </>
+        ) : (
+          <MenuItem
+            key={JSON.stringify(entry)}
+            dense
+            onClick={() => {
+              model.removeStructureFromSelection({
+                structure: entry,
+                id: node.name,
+              })
+              onClose()
+            }}
+          >
+            Remove PDB from selection ({entry.pdb})
+          </MenuItem>
+        ),
+      )}
+
+      {// @ts-expect-error
+      nodeDetails?.data.accession?.map(accession => (
+        <MenuItem
+          dense
+          key={accession}
+          onClick={() => {
+            model.addUniprotTrack({
+              // @ts-expect-error
+              name: nodeDetails?.data.name,
+              accession,
+            })
+            onClose()
+          }}
+        >
+          Open UniProt track ({accession})
+        </MenuItem>
+      ))}
+    </Menu>
   )
 })
 

--- a/lib/src/components/TreePanel/TreeNodeMenu.tsx
+++ b/lib/src/components/TreePanel/TreeNodeMenu.tsx
@@ -17,7 +17,7 @@ const TreeMenu = observer(function ({
   model: MsaViewModel
   onClose: () => void
 }) {
-  const { selectedStructures, collapsed, structures } = model
+  const { selectedStructures, collapsed, collapsed2, structures } = model
   const nodeDetails = node ? model.getRowData(node.name) : undefined
 
   return (
@@ -56,11 +56,21 @@ const TreeMenu = observer(function ({
       <MenuItem
         dense
         onClick={() => {
-          model.toggleCollapsed(node.id)
+          if (collapsed.includes(node.id)) {
+            model.toggleCollapsed(node.id)
+          } else {
+            if (node.id.endsWith('-leafnode')) {
+              model.toggleCollapsed2(`${node.id}`)
+            } else {
+              model.toggleCollapsed2(`${node.id}-leafnode`)
+            }
+          }
           onClose()
         }}
       >
-        {collapsed.includes(node.id) ? 'Show node' : 'Hide node'}
+        {collapsed.includes(node.id) || collapsed2.includes(node.id)
+          ? 'Show node'
+          : 'Hide node'}
       </MenuItem>
 
       {structures[node.name]?.map(entry =>

--- a/lib/src/components/TreePanel/renderTreeCanvas.ts
+++ b/lib/src/components/TreePanel/renderTreeCanvas.ts
@@ -90,6 +90,7 @@ export function renderNodeBubbles({
     } = node
     const { branchset, id = '', name = '' } = data
     if (
+      !id.endsWith('-leafnode') &&
       branchset.length &&
       y > offsetY - extendBounds &&
       y < offsetY + by + extendBounds

--- a/lib/src/components/dialogs/SettingsDialog.tsx
+++ b/lib/src/components/dialogs/SettingsDialog.tsx
@@ -35,142 +35,146 @@ function FormControlLabel2(rest: FormControlLabelProps) {
   )
 }
 
+function Checkbox2({
+  checked,
+  label,
+  onChange,
+}: {
+  checked: boolean
+  label: string
+  onChange: () => void
+}) {
+  return (
+    <FormControlLabel2
+      control={<Checkbox checked={checked} onChange={onChange} />}
+      label={label}
+    />
+  )
+}
+
 const SettingsContent = observer(function ({ model }: { model: MsaViewModel }) {
+  return (
+    <>
+      <TreeSettings model={model} />
+      <MSASettings model={model} />
+    </>
+  )
+})
+
+function TreeSettings({ model }: { model: MsaViewModel }) {
   const { classes } = useStyles()
   const {
-    bgColor,
-    colWidth,
-    colorSchemeName,
     drawTree,
     drawNodeBubbles,
     labelsAlignRight,
     noTree,
-    rowHeight,
     showBranchLen,
     treeWidthMatchesArea,
     treeWidth,
   } = model
+
   return (
-    <>
-      <div>
-        <Button onClick={() => model.clearHidden()}>Clear hidden</Button>
-        <h1>Tree options</h1>
-        <FormControlLabel2
-          control={
-            <Checkbox
-              checked={showBranchLen}
-              onChange={() => model.setShowBranchLen(!showBranchLen)}
-            />
-          }
-          label="Show branch length?"
-        />
+    <div>
+      <h1>Tree options</h1>
+      <Checkbox2
+        checked={showBranchLen}
+        onChange={() => model.setShowBranchLen(!showBranchLen)}
+        label="Show branch length?"
+      />
 
-        <FormControlLabel2
-          control={
-            <Checkbox
-              checked={drawNodeBubbles}
-              onChange={() => model.setDrawNodeBubbles(!drawNodeBubbles)}
-            />
-          }
-          label="Draw clickable bubbles on tree branches?"
-        />
-        <FormControlLabel2
-          control={
-            <Checkbox
-              checked={drawTree}
-              onChange={() => model.setDrawTree(!drawTree)}
-            />
-          }
-          label="Show tree?"
-        />
+      <Checkbox2
+        checked={drawNodeBubbles}
+        onChange={() => model.setDrawNodeBubbles(!drawNodeBubbles)}
+        label="Draw clickable bubbles on tree branches?"
+      />
+      <Checkbox2
+        checked={drawTree}
+        onChange={() => model.setDrawTree(!drawTree)}
+        label="Show tree?"
+      />
 
-        <FormControlLabel2
-          control={
-            <Checkbox
-              checked={labelsAlignRight}
-              onChange={() => model.setLabelsAlignRight(!labelsAlignRight)}
-            />
-          }
-          label="Tree labels align right?"
-        />
-        {!noTree ? (
-          <div>
-            <FormControlLabel2
-              control={
-                <Checkbox
-                  checked={treeWidthMatchesArea}
-                  onChange={() =>
-                    model.setTreeWidthMatchesArea(!treeWidthMatchesArea)
-                  }
-                />
-              }
-              label="Make tree width fit to tree area?"
-            />
-            {!treeWidthMatchesArea ? (
-              <div className={classes.flex}>
-                <Typography>Tree width ({treeWidth}px)</Typography>
-                <Slider
-                  className={classes.field}
-                  min={50}
-                  max={600}
-                  value={treeWidth}
-                  onChange={(_, val) => model.setTreeWidth(val as number)}
-                />
-              </div>
-            ) : null}
-          </div>
-        ) : null}
-      </div>
-      <div>
-        <h1>MSA options</h1>
-
-        <FormControlLabel2
-          control={
-            <Checkbox
-              checked={bgColor}
-              onChange={() => model.setBgColor(!bgColor)}
-            />
-          }
-          label="Color background tiles of MSA?"
-        />
-
-        <div className={classes.flex}>
-          <Typography>Column width ({colWidth}px)</Typography>
-          <Slider
-            className={classes.field}
-            min={1}
-            max={50}
-            value={colWidth}
-            onChange={(_, val) => model.setColWidth(val as number)}
+      <Checkbox2
+        checked={labelsAlignRight}
+        onChange={() => model.setLabelsAlignRight(!labelsAlignRight)}
+        label="Tree labels align right?"
+      />
+      {!noTree ? (
+        <div>
+          <Checkbox2
+            checked={treeWidthMatchesArea}
+            onChange={() =>
+              model.setTreeWidthMatchesArea(!treeWidthMatchesArea)
+            }
+            label="Make tree width fit to tree area?"
           />
+          {!treeWidthMatchesArea ? (
+            <div className={classes.flex}>
+              <Typography>Tree width ({treeWidth}px)</Typography>
+              <Slider
+                className={classes.field}
+                min={50}
+                max={600}
+                value={treeWidth}
+                onChange={(_, val) => model.setTreeWidth(val as number)}
+              />
+            </div>
+          ) : null}
         </div>
-        <div className={classes.flex}>
-          <Typography>Row height ({rowHeight}px)</Typography>
-          <Slider
-            className={classes.field}
-            min={1}
-            max={50}
-            value={rowHeight}
-            onChange={(_, val) => model.setRowHeight(val as number)}
-          />
-        </div>
-
-        <TextField
-          select
-          label="Color scheme"
-          value={colorSchemeName}
-          onChange={event => model.setColorSchemeName(event.target.value)}
-        >
-          {Object.keys(colorSchemes).map(option => (
-            <MenuItem key={option} value={option}>
-              {option}
-            </MenuItem>
-          ))}
-        </TextField>
-      </div>
-    </>
+      ) : null}
+    </div>
   )
-})
+}
+
+function MSASettings({ model }: { model: MsaViewModel }) {
+  const { classes } = useStyles()
+  const { bgColor, colWidth, colorSchemeName, rowHeight } = model
+
+  return (
+    <div>
+      <h1>MSA options</h1>
+
+      <Checkbox2
+        checked={bgColor}
+        onChange={() => model.setBgColor(!bgColor)}
+        label="Color background tiles of MSA?"
+      />
+
+      <div className={classes.flex}>
+        <Typography>Column width ({colWidth}px)</Typography>
+        <Slider
+          className={classes.field}
+          min={1}
+          max={50}
+          value={colWidth}
+          onChange={(_, val) => model.setColWidth(val as number)}
+        />
+      </div>
+      <div className={classes.flex}>
+        <Typography>Row height ({rowHeight}px)</Typography>
+        <Slider
+          className={classes.field}
+          min={1}
+          max={50}
+          value={rowHeight}
+          onChange={(_, val) => model.setRowHeight(val as number)}
+        />
+      </div>
+
+      <TextField
+        select
+        label="Color scheme"
+        value={colorSchemeName}
+        onChange={event => model.setColorSchemeName(event.target.value)}
+      >
+        {Object.keys(colorSchemes).map(option => (
+          <MenuItem key={option} value={option}>
+            {option}
+          </MenuItem>
+        ))}
+      </TextField>
+    </div>
+  )
+}
 
 const SettingsDialog = observer(function ({
   model,

--- a/lib/src/util.ts
+++ b/lib/src/util.ts
@@ -145,17 +145,6 @@ export function collapse(d: HierarchyNode<NodeWithIds>) {
   }
 }
 
-// Collapse the node and all it's children, from
-// https://bl.ocks.org/d3noob/43a860bc0024792f8803bba8ca0d5ecd
-export function filterHiddenLeafNodes(
-  d: HierarchyNode<NodeWithIds> | null,
-  hiddenId?: string,
-) {
-  if (d?.children) {
-    d.children = d.children.filter(f => f.id !== hiddenId)
-  }
-}
-
 export function clamp(min: number, num: number, max: number) {
   return Math.min(Math.max(num, min), max)
 }


### PR DESCRIPTION
Currently, the app is not able to hide single "leaf" nodes. Only collapsing top level nodes with multiple children was allowed.  This adds that ability. 

The change requires re-parsing the tree data structure to make it so that the leafs actualy have a new parent and then they are the singular child of that parent. 

The above technique allows hiding leaf nodes to use the same logic that hiding parent nodes does (which is just saying `node.oldChildren=node.children; node.children=null` while collapsed and restoring from oldChildren when restored)