### PR TITLE
Allow user to configure amount of allowed "gappyness"

### DIFF
--- a/lib/src/components/dialogs/SettingsDialog.tsx
+++ b/lib/src/components/dialogs/SettingsDialog.tsx
@@ -119,8 +119,10 @@ const MSASettings = observer(function MSASettings({
     bgColor,
     contrastLettering,
     colWidth,
+    allowedGappyness,
     drawMsaLetters,
     colorSchemeName,
+    hideGaps,
     rowHeight,
   } = model
 
@@ -141,6 +143,11 @@ const MSASettings = observer(function MSASettings({
         checked={contrastLettering}
         onChange={() => model.setContrastLettering(!contrastLettering)}
         label="Use contrast lettering"
+      />
+      <Checkbox2
+        checked={hideGaps}
+        onChange={() => model.setHideGaps(!hideGaps)}
+        label={`Hide columns that are ${100 - allowedGappyness}% gaps`}
       />
 
       <div className={classes.flex}>
@@ -163,6 +170,18 @@ const MSASettings = observer(function MSASettings({
           onChange={(_, val) => model.setRowHeight(val as number)}
         />
       </div>
+      {hideGaps ? (
+        <div className={classes.flex}>
+          <Typography>Allowed gappyness ({100 - allowedGappyness}%)</Typography>
+          <Slider
+            className={classes.field}
+            min={1}
+            max={100}
+            value={allowedGappyness}
+            onChange={(_, val) => model.setAllowedGappyness(val as number)}
+          />
+        </div>
+      ) : null}
 
       <TextField
         select

--- a/lib/src/components/msa/renderMSABlock.ts
+++ b/lib/src/components/msa/renderMSABlock.ts
@@ -132,9 +132,13 @@ function drawTiles({
               )
             : colorScheme[letter.toUpperCase()]
       if (bgColor) {
-        const x = i * colWidth + offsetX - (offsetX % colWidth)
         ctx.fillStyle = color || theme.palette.background.default
-        ctx.fillRect(x, y - rowHeight, colWidth, rowHeight)
+        ctx.fillRect(
+          i * colWidth + offsetX - (offsetX % colWidth),
+          y - rowHeight,
+          colWidth,
+          rowHeight,
+        )
       }
     }
   }

--- a/lib/src/model.ts
+++ b/lib/src/model.ts
@@ -106,6 +106,10 @@ function stateModelFactory() {
         /**
          * #property
          */
+        allowedGappyness: 100,
+        /**
+         * #property
+         */
         contrastLettering: true,
 
         /**
@@ -123,6 +127,10 @@ function stateModelFactory() {
          * #property
          */
         drawMsaLetters: true,
+        /**
+         * #property
+         */
+        hideGaps: true,
 
         /**
          * #property
@@ -320,6 +328,18 @@ function stateModelFactory() {
         | Record<string, InterProScanResults>,
     }))
     .actions(self => ({
+      /**
+       * #action
+       */
+      setHideGaps(arg: boolean) {
+        self.hideGaps = arg
+      },
+      /**
+       * #action
+       */
+      setAllowedGappyness(arg: number) {
+        self.allowedGappyness = arg
+      },
       /**
        * #action
        */
@@ -669,6 +689,7 @@ function stateModelFactory() {
        * #getter
        */
       get blanks() {
+        const { allowedGappyness } = self
         const blanks = []
         const strs = this.leaves
           .map(leaf => this.MSA?.getRow(leaf.data.name))
@@ -681,7 +702,7 @@ function stateModelFactory() {
               counter++
             }
           }
-          if (counter === strs.length) {
+          if (counter / strs.length >= allowedGappyness / 100) {
             blanks.push(i)
           }
         }

--- a/lib/src/model.ts
+++ b/lib/src/model.ts
@@ -670,8 +670,7 @@ function stateModelFactory() {
        */
       get blanks() {
         const blanks = []
-        const strs = this.hierarchy
-          .leaves()
+        const strs = this.leaves
           .map(leaf => this.MSA?.getRow(leaf.data.name))
           .filter((item): item is string => !!item)
 
@@ -693,8 +692,7 @@ function stateModelFactory() {
        */
       get rows() {
         const MSA = this.MSA
-        return this.hierarchy
-          .leaves()
+        return this.leaves
           .map(leaf => [leaf.data.name, MSA?.getRow(leaf.data.name)] as const)
           .filter((f): f is [string, string] => !!f[1])
       },
@@ -767,14 +765,7 @@ function stateModelFactory() {
        * #getter
        */
       get totalHeight() {
-        return this.leaves.length * self.rowHeight
-      },
-
-      /**
-       * #getter
-       */
-      get leaves() {
-        return this.hierarchy.leaves()
+        return this.root.leaves().length * self.rowHeight
       },
 
       /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1535,9 +1535,9 @@ callsites@^3.0.0:
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
 caniuse-lite@^1.0.30001646:
-  version "1.0.30001650"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001650.tgz#dd1eba0938e39536d184c3c99b2569a13788bc16"
-  integrity sha512-fgEc7hP/LB7iicdXHUI9VsBsMZmUmlVJeQP2qqQW+3lkqVhbmjEU8zp+h5stWeilX+G7uXuIUIIlWlDw9jdt8g==
+  version "1.0.30001651"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz#52de59529e8b02b1aedcaaf5c05d9e23c0c28138"
+  integrity sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==
 
 canvas-sequencer@^3.1.0:
   version "3.1.0"
@@ -2291,9 +2291,9 @@ for-each@^0.3.3:
     is-callable "^1.1.3"
 
 foreground-child@^3.1.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.2.1.tgz#767004ccf3a5b30df39bed90718bab43fe0a59f7"
-  integrity sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.0.tgz#0ac8644c06e431439f8561db8ecf29a7b5519c77"
+  integrity sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==
   dependencies:
     cross-spawn "^7.0.0"
     signal-exit "^4.0.1"
@@ -3909,9 +3909,9 @@ synckit@^0.9.1:
     tslib "^2.6.2"
 
 terser@^5.17.4:
-  version "5.31.4"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.31.4.tgz#60274c4d3e20eb9a6468526a8878aba8e8428c5f"
-  integrity sha512-3OU03GgblDgu0g+sdnsVzhBPxnjV+WJuMmocN1qBBZDQ3ia7jZQSAkePeKbPlYAejGXUTYe1CmSaUeV51mvaIw==
+  version "5.31.5"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.31.5.tgz#e48b7c65f32d2808e7dad803e4586a0bc3829b87"
+  integrity sha512-YPmas0L0rE1UyLL/llTWA0SiDOqIcAQYLeUj7cJYzXHlRTAnMSg9pPe4VJ5PlKvTrPQsdVFuiRiwyeNlYgwh2Q==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.8.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1535,9 +1535,9 @@ callsites@^3.0.0:
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
 caniuse-lite@^1.0.30001646:
-  version "1.0.30001649"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001649.tgz#3ec700309ca0da2b0d3d5fb03c411b191761c992"
-  integrity sha512-fJegqZZ0ZX8HOWr6rcafGr72+xcgJKI9oWfDW5DrD7ExUtgZC7a7R7ZYmZqplh7XDocFdGeIFn7roAxhOeYrPQ==
+  version "1.0.30001650"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001650.tgz#dd1eba0938e39536d184c3c99b2569a13788bc16"
+  integrity sha512-fgEc7hP/LB7iicdXHUI9VsBsMZmUmlVJeQP2qqQW+3lkqVhbmjEU8zp+h5stWeilX+G7uXuIUIIlWlDw9jdt8g==
 
 canvas-sequencer@^3.1.0:
   version "3.1.0"
@@ -1808,9 +1808,9 @@ eastasianwidth@^0.2.0:
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
 electron-to-chromium@^1.5.4:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.4.tgz#cd477c830dd6fca41fbd5465c1ff6ce08ac22343"
-  integrity sha512-orzA81VqLyIGUEA77YkVA1D+N+nNfl2isJVjjmOyrlxuooZ19ynb+dOlaDTqd/idKRS9lDCSBmtzM+kyCsMnkA==
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.5.tgz#03bfdf422bdd2c05ee2657efedde21264a1a566b"
+  integrity sha512-QR7/A7ZkMS8tZuoftC/jfqNkZLQO779SSW3YuZHP4eXpj3EffGLFcB/Xu9AAZQzLccTiCV+EmUo3ha4mQ9wnlA==
 
 email-addresses@^5.0.0:
   version "5.0.0"
@@ -3313,7 +3313,7 @@ possible-typed-array-names@^1.0.0:
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz#89bb63c6fada2c3e90adc4a647beeeb39cc7bf8f"
   integrity sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==
 
-postcss@^8.4.39:
+postcss@^8.4.40:
   version "8.4.41"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.41.tgz#d6104d3ba272d882fe18fc07d15dc2da62fa2681"
   integrity sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==
@@ -3909,9 +3909,9 @@ synckit@^0.9.1:
     tslib "^2.6.2"
 
 terser@^5.17.4:
-  version "5.31.3"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.31.3.tgz#b24b7beb46062f4653f049eea4f0cd165d0f0c38"
-  integrity sha512-pAfYn3NIZLyZpa83ZKigvj6Rn9c/vd5KfYGX7cN1mnzqgDcxWvrU5ZtAfIKhEXz9nRecw4z3LXkjaq96/qZqAA==
+  version "5.31.4"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.31.4.tgz#60274c4d3e20eb9a6468526a8878aba8e8428c5f"
+  integrity sha512-3OU03GgblDgu0g+sdnsVzhBPxnjV+WJuMmocN1qBBZDQ3ia7jZQSAkePeKbPlYAejGXUTYe1CmSaUeV51mvaIw==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.8.2"
@@ -4086,12 +4086,12 @@ validate-npm-package-license@^3.0.1:
     spdx-expression-parse "^3.0.0"
 
 vite@^5.0.10:
-  version "5.3.5"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-5.3.5.tgz#b847f846fb2b6cb6f6f4ed50a830186138cb83d8"
-  integrity sha512-MdjglKR6AQXQb9JGiS7Rc2wC6uMjcm7Go/NHNO63EwiJXfuk9PgqiP/n5IDJCziMkfw9n4Ubp7lttNwz+8ZVKA==
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.0.tgz#11dca8a961369ba8b5cae42d068c7ad684d5370f"
+  integrity sha512-5xokfMX0PIiwCMCMb9ZJcMyh5wbBun0zUzKib+L65vAZ8GY9ePZMXxFrHbr/Kyll2+LSCY7xtERPpxkBDKngwg==
   dependencies:
     esbuild "^0.21.3"
-    postcss "^8.4.39"
+    postcss "^8.4.40"
     rollup "^4.13.0"
   optionalDependencies:
     fsevents "~2.3.3"


### PR DESCRIPTION
This let's you hide columns that have a certain gappyness percentage

This is a feature implemented by wasabi (http://wasabiapp.org)  and foldmason (https://search.foldseek.com/foldmason)

It also allows you to disable the default setting that we have to hide columns that are 100% gaps. this was a feature that was requested by HIV database awhile back. They are using a fork of the codebase but it might still help people who want to remain on master. The use case was that a metadata track in stockholm file stored the reference sequence, and then the msa columns could be 100% gaps relative to that reference, which they did not want to automatically hide/collapse.

