### PR TITLE
CLI: add Docker/Singularity runners

### DIFF
--- a/packages/cli/src/docker-runner.ts
+++ b/packages/cli/src/docker-runner.ts
@@ -1,0 +1,103 @@
+import { spawn } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import path from 'node:path'
+
+import { toFasta } from './util.ts'
+
+import type { InterProScanResponse, InterProScanResults } from 'msa-parsers'
+
+const INTERPROSCAN_IMAGE = 'interpro/interproscan:latest'
+
+export async function runDockerInterProScan(
+  sequences: { id: string; seq: string }[],
+  programs: string[],
+): Promise<InterProScanResults[]> {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'interproscan-'))
+  const inputFile = path.join(tmpDir, 'input.fasta')
+
+  try {
+    fs.writeFileSync(inputFile, toFasta(sequences), 'utf8')
+
+    console.log(
+      `  Running InterProScan via Docker on ${sequences.length} sequences...`,
+    )
+    console.log(`  Image: ${INTERPROSCAN_IMAGE}`)
+
+    await new Promise<void>((resolve, reject) => {
+      const args = [
+        'run',
+        '--rm',
+        '-v',
+        `${tmpDir}:/data`,
+        INTERPROSCAN_IMAGE,
+        '-i',
+        '/data/input.fasta',
+        '-o',
+        '/data/output.json',
+        '-f',
+        'JSON',
+        '-appl',
+        programs.join(','),
+      ]
+
+      console.log(`  docker ${args.join(' ')}`)
+
+      const proc = spawn('docker', args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+
+      proc.stdout.on('data', (data: Buffer) => {
+        const line = data.toString().trim()
+        if (line) {
+          console.log(`  ${line}`)
+        }
+      })
+
+      let stderr = ''
+      proc.stderr.on('data', (data: Buffer) => {
+        stderr += data.toString()
+        const line = data.toString().trim()
+        if (line) {
+          console.log(`  ${line}`)
+        }
+      })
+
+      proc.on('close', code => {
+        if (code === 0) {
+          resolve()
+        } else {
+          reject(
+            new Error(
+              `Docker InterProScan failed with code ${code}: ${stderr}`,
+            ),
+          )
+        }
+      })
+
+      proc.on('error', err => {
+        reject(
+          new Error(
+            `Failed to run Docker: ${err.message}. Is Docker installed and running?`,
+          ),
+        )
+      })
+    })
+
+    const outputFile = path.join(tmpDir, 'output.json')
+    if (!fs.existsSync(outputFile)) {
+      throw new Error('InterProScan did not produce output file')
+    }
+
+    const outputContent = fs.readFileSync(outputFile, 'utf8')
+    const response: InterProScanResponse = JSON.parse(outputContent)
+
+    return response.results
+  } finally {
+    try {
+      fs.rmSync(tmpDir, { recursive: true })
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+}

--- a/packages/cli/src/ebi-api.ts
+++ b/packages/cli/src/ebi-api.ts
@@ -1,11 +1,9 @@
-import { toFasta } from './util.ts'
-
 import type { InterProScanResponse, InterProScanResults } from 'msa-parsers'
 
 const BASE_URL = 'https://www.ebi.ac.uk/Tools/services/rest/iprscan5'
 
 async function submitJob(
-  sequences: { id: string; seq: string }[],
+  sequence: { id: string; seq: string },
   programs: string[],
   email: string,
 ): Promise<string> {
@@ -16,13 +14,14 @@ async function submitJob(
     },
     body: new URLSearchParams({
       email,
-      sequence: toFasta(sequences),
+      sequence: `>${sequence.id}\n${sequence.seq}`,
       appl: programs.join(','),
     }),
   })
 
   if (!response.ok) {
-    throw new Error(`Failed to submit job: ${response.statusText}`)
+    const text = await response.text()
+    throw new Error(`Failed to submit job: ${response.statusText} - ${text}`)
   }
 
   return response.text()
@@ -45,9 +44,8 @@ async function getResults(jobId: string): Promise<InterProScanResponse> {
 }
 
 async function waitForJob(jobId: string): Promise<void> {
-  console.log(`  Waiting for job ${jobId}...`)
   let attempts = 0
-  const maxAttempts = 300 // 5 minutes max wait
+  const maxAttempts = 300
 
   while (attempts < maxAttempts) {
     const status = await checkStatus(jobId)
@@ -74,25 +72,16 @@ export async function runEbiInterProScan(
   sequences: { id: string; seq: string }[],
   programs: string[],
   email: string,
-  batchSize: number,
+  _batchSize: number,
 ): Promise<InterProScanResults[]> {
   const allResults: InterProScanResults[] = []
-  const batches: { id: string; seq: string }[][] = []
 
-  for (let i = 0; i < sequences.length; i += batchSize) {
-    batches.push(sequences.slice(i, i + batchSize))
-  }
+  for (let i = 0; i < sequences.length; i++) {
+    const seq = sequences[i]!
+    console.log(`  [${i + 1}/${sequences.length}] Submitting ${seq.id}...`)
 
-  console.log(`  Submitting ${batches.length} batch(es)...`)
-
-  for (let i = 0; i < batches.length; i++) {
-    const batch = batches[i]!
-    console.log(
-      `  Processing batch ${i + 1}/${batches.length} (${batch.length} sequences)...`,
-    )
-
-    const jobId = await submitJob(batch, programs, email)
-    console.log(`  Job submitted: ${jobId}`)
+    const jobId = await submitJob(seq, programs, email)
+    console.log(`  Job: ${jobId}`)
 
     await waitForJob(jobId)
 
@@ -101,7 +90,7 @@ export async function runEbiInterProScan(
       allResults.push(r)
     }
 
-    console.log(`  Batch ${i + 1} complete`)
+    console.log(`  [${i + 1}/${sequences.length}] Done`)
   }
 
   return allResults

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,13 +16,25 @@ const { values, positionals } = parseArgs({
       type: 'boolean',
       default: false,
     },
+    docker: {
+      type: 'boolean',
+      default: false,
+    },
+    singularity: {
+      type: 'boolean',
+      default: false,
+    },
+    'singularity-image': {
+      type: 'string',
+      default: 'docker://interpro/interproscan:latest',
+    },
     'interproscan-path': {
       type: 'string',
       default: 'interproscan.sh',
     },
     programs: {
       type: 'string',
-      default: 'Pfam',
+      default: 'PfamA,CDD',
     },
     email: {
       type: 'string',
@@ -53,21 +65,30 @@ COMMANDS:
 OPTIONS:
   -o, --output <file>           Output GFF file (default: domains.gff)
   --local                       Use local InterProScan installation
+  --docker                      Use Docker (interpro/interproscan image)
+  --singularity                 Use Singularity/Apptainer container
+  --singularity-image <image>   Singularity image (default: docker://interpro/interproscan:latest)
   --interproscan-path <path>    Path to interproscan.sh (default: interproscan.sh)
-  --programs <list>             Comma-separated list of programs (default: Pfam)
+  --programs <list>             Comma-separated list of programs (default: PfamA,CDD)
   --email <email>               Email for EBI API (default: user@example.com)
   --batch-size <n>              Number of sequences per API batch (default: 30)
   -h, --help                    Show this help message
 
 EXAMPLES:
-  # Run InterProScan using EBI API
+  # Run InterProScan using EBI API (one sequence at a time)
   react-msaview-cli interproscan alignment.fasta -o domains.gff
 
-  # Run with local InterProScan
+  # Run with Docker (processes all sequences locally, much faster)
+  react-msaview-cli interproscan alignment.fasta -o domains.gff --docker
+
+  # Run with local InterProScan installation
   react-msaview-cli interproscan alignment.fasta -o domains.gff --local
 
-  # Specify programs
-  react-msaview-cli interproscan alignment.clustal -o domains.gff --programs Pfam,SMART
+  # Run with Singularity using a local .sif file
+  react-msaview-cli interproscan alignment.fasta -o domains.gff --singularity --singularity-image /path/to/interproscan.sif
+
+  # Run with Singularity pulling from Docker Hub (requires network)
+  react-msaview-cli interproscan alignment.fasta -o domains.gff --singularity
 `)
 }
 
@@ -90,6 +111,9 @@ async function main() {
       inputFile,
       outputFile: values.output,
       useLocal: values.local,
+      useDocker: values.docker,
+      useSingularity: values.singularity,
+      singularityImage: values['singularity-image'],
       interproscanPath: values['interproscan-path'],
       programs: values.programs.split(','),
       email: values.email,

--- a/packages/cli/src/interproscan-msa.ts
+++ b/packages/cli/src/interproscan-msa.ts
@@ -6,8 +6,10 @@ import {
   parseMSA,
 } from 'msa-parsers'
 
+import { runDockerInterProScan } from './docker-runner'
 import { runEbiInterProScan } from './ebi-api'
 import { runLocalInterProScan } from './local-runner'
+import { runSingularityInterProScan } from './singularity-runner'
 
 import type { InterProScanResults } from 'msa-parsers'
 
@@ -15,6 +17,9 @@ export interface InterProScanOptions {
   inputFile: string
   outputFile: string
   useLocal: boolean
+  useDocker: boolean
+  useSingularity: boolean
+  singularityImage: string
   interproscanPath: string
   programs: string[]
   email: string
@@ -26,6 +31,9 @@ export async function runInterProScan(options: InterProScanOptions) {
     inputFile,
     outputFile,
     useLocal,
+    useDocker,
+    useSingularity,
+    singularityImage,
     interproscanPath,
     programs,
     email,
@@ -52,7 +60,17 @@ export async function runInterProScan(options: InterProScanOptions) {
 
   let allResults: InterProScanResults[]
 
-  if (useLocal) {
+  if (useSingularity) {
+    console.log('Running InterProScan via Singularity...')
+    allResults = await runSingularityInterProScan(
+      sequences,
+      programs,
+      singularityImage,
+    )
+  } else if (useDocker) {
+    console.log('Running InterProScan via Docker...')
+    allResults = await runDockerInterProScan(sequences, programs)
+  } else if (useLocal) {
     console.log(`Running local InterProScan at ${interproscanPath}...`)
     allResults = await runLocalInterProScan(
       sequences,
@@ -60,11 +78,11 @@ export async function runInterProScan(options: InterProScanOptions) {
       programs,
     )
   } else {
-    console.log(`Running InterProScan via EBI API...`)
+    console.log('Running InterProScan via EBI API...')
     allResults = await runEbiInterProScan(sequences, programs, email, batchSize)
   }
 
-  console.log(`Converting results to GFF...`)
+  console.log('Converting results to GFF...')
   const gff = interProResponseToGFF(allResults)
 
   console.log(`Writing output to ${outputFile}...`)

--- a/packages/cli/src/singularity-runner.ts
+++ b/packages/cli/src/singularity-runner.ts
@@ -1,0 +1,104 @@
+import { spawn } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import path from 'node:path'
+
+import { toFasta } from './util.ts'
+
+import type { InterProScanResponse, InterProScanResults } from 'msa-parsers'
+
+const DEFAULT_SINGULARITY_IMAGE = 'docker://interpro/interproscan:latest'
+
+export async function runSingularityInterProScan(
+  sequences: { id: string; seq: string }[],
+  programs: string[],
+  imagePath = DEFAULT_SINGULARITY_IMAGE,
+): Promise<InterProScanResults[]> {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'interproscan-'))
+  const inputFile = path.join(tmpDir, 'input.fasta')
+
+  try {
+    fs.writeFileSync(inputFile, toFasta(sequences), 'utf8')
+
+    console.log(
+      `  Running InterProScan via Singularity on ${sequences.length} sequences...`,
+    )
+    console.log(`  Image: ${imagePath}`)
+
+    await new Promise<void>((resolve, reject) => {
+      const args = [
+        'exec',
+        '--bind',
+        `${tmpDir}:/data`,
+        imagePath,
+        '/opt/interproscan/interproscan.sh',
+        '-i',
+        '/data/input.fasta',
+        '-o',
+        '/data/output.json',
+        '-f',
+        'JSON',
+        '-appl',
+        programs.join(','),
+      ]
+
+      console.log(`  singularity ${args.join(' ')}`)
+
+      const proc = spawn('singularity', args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+
+      proc.stdout.on('data', (data: Buffer) => {
+        const line = data.toString().trim()
+        if (line) {
+          console.log(`  ${line}`)
+        }
+      })
+
+      let stderr = ''
+      proc.stderr.on('data', (data: Buffer) => {
+        stderr += data.toString()
+        const line = data.toString().trim()
+        if (line) {
+          console.log(`  ${line}`)
+        }
+      })
+
+      proc.on('close', code => {
+        if (code === 0) {
+          resolve()
+        } else {
+          reject(
+            new Error(
+              `Singularity InterProScan failed with code ${code}: ${stderr}`,
+            ),
+          )
+        }
+      })
+
+      proc.on('error', err => {
+        reject(
+          new Error(
+            `Failed to run Singularity: ${err.message}. Is Singularity/Apptainer installed?`,
+          ),
+        )
+      })
+    })
+
+    const outputFile = path.join(tmpDir, 'output.json')
+    if (!fs.existsSync(outputFile)) {
+      throw new Error('InterProScan did not produce output file')
+    }
+
+    const outputContent = fs.readFileSync(outputFile, 'utf8')
+    const response: InterProScanResponse = JSON.parse(outputContent)
+
+    return response.results
+  } finally {
+    try {
+      fs.rmSync(tmpDir, { recursive: true })
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+}


### PR DESCRIPTION
Adds `--docker` and `--singularity` flags to run InterProScan locally via containers instead of the EBI API. Also fixes the EBI API to submit one sequence at a time.