### PR TITLE
Robustness fixes and SVG export simplification

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -42,6 +42,8 @@ jobs:
         run: |
           cd packages/lib
           node --experimental-strip-types docgen/generateStateModelDocs.ts
+          # match the committed docs, which pnpm statedocs formats via prettier
+          npx prettier --write apidocs
           if ! git diff --quiet apidocs; then
             echo "apidocs are out of date — run pnpm statedocs and commit the result"
             git diff apidocs

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "vitest",
     "figures": "vitest run --config vitest.figures.config.ts",
     "screenshots": "pnpm --filter app exec vite build && node scripts/screenshots/generate.mjs",
-    "typecheck": "pnpm -r --filter=!website exec tsc --noEmit && pnpm --filter website exec tsc --noEmit",
+    "typecheck": "pnpm -r --filter=!website exec tsc --noEmit && pnpm --filter website exec astro sync && pnpm --filter website exec tsc --noEmit",
     "release": "node scripts/release.js",
     "release:patch": "node scripts/release.js patch",
     "release:minor": "node scripts/release.js minor",

--- a/packages/cli/src/export-svg.ts
+++ b/packages/cli/src/export-svg.ts
@@ -6,36 +6,62 @@ import { enableStaticRendering } from 'mobx-react'
 
 // minimal 2d-affine DOMMatrix needed by svgcanvas: [a c e / b d f / 0 0 1]
 class Mat {
-  a = 1; b = 0; c = 0; d = 1; e = 0; f = 0
+  a = 1
+  b = 0
+  c = 0
+  d = 1
+  e = 0
+  f = 0
   constructor(init?: number[]) {
     if (init && init.length >= 6) {
-      this.a = init[0]!; this.b = init[1]!; this.c = init[2]!
-      this.d = init[3]!; this.e = init[4]!; this.f = init[5]!
+      this.a = init[0]!
+      this.b = init[1]!
+      this.c = init[2]!
+      this.d = init[3]!
+      this.e = init[4]!
+      this.f = init[5]!
     }
   }
   multiply(o: Mat) {
     return new Mat([
-      this.a * o.a + this.c * o.b, this.b * o.a + this.d * o.b,
-      this.a * o.c + this.c * o.d, this.b * o.c + this.d * o.d,
-      this.a * o.e + this.c * o.f + this.e, this.b * o.e + this.d * o.f + this.f,
+      this.a * o.a + this.c * o.b,
+      this.b * o.a + this.d * o.b,
+      this.a * o.c + this.c * o.d,
+      this.b * o.c + this.d * o.d,
+      this.a * o.e + this.c * o.f + this.e,
+      this.b * o.e + this.d * o.f + this.f,
     ])
   }
-  translate(x: number, y = 0) { return this.multiply(new Mat([1, 0, 0, 1, x, y])) }
-  scale(x: number, y = x)    { return this.multiply(new Mat([x, 0, 0, y, 0, 0])) }
+  translate(x: number, y = 0) {
+    return this.multiply(new Mat([1, 0, 0, 1, x, y]))
+  }
+  scale(x: number, y = x) {
+    return this.multiply(new Mat([x, 0, 0, y, 0, 0]))
+  }
 }
 
 class Pt {
-  constructor(public x = 0, public y = 0) {}
+  constructor(
+    public x = 0,
+    public y = 0,
+  ) {}
   matrixTransform(m: Mat) {
-    return new Pt(m.a * this.x + m.c * this.y + m.e, m.b * this.x + m.d * this.y + m.f)
+    return new Pt(
+      m.a * this.x + m.c * this.y + m.e,
+      m.b * this.x + m.d * this.y + m.f,
+    )
   }
 }
 
 function makeCtx() {
   let font = '10px sans-serif'
   return {
-    get font() { return font },
-    set font(v: string) { font = v },
+    get font() {
+      return font
+    },
+    set font(v: string) {
+      font = v
+    },
     measureText(t: string) {
       const size = Number.parseFloat(font) || 10
       return { width: t.length * size * 0.6 } as TextMetrics
@@ -49,12 +75,14 @@ function setupPolyfills() {
   // jsdom provides document/window/SVGElement needed by svgcanvas and measureTextCanvas
   const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>')
   const g = globalThis as Record<string, unknown>
-  g['window'] = dom.window
-  g['document'] = dom.window.document
-  g['DOMMatrix'] = Mat
-  g['DOMPoint'] = Pt
+  g.window = dom.window
+  g.document = dom.window.document
+  g.DOMMatrix = Mat
+  g.DOMPoint = Pt
   // override jsdom's stub canvas context with our text-metrics mock
-  ;(dom.window.HTMLCanvasElement.prototype as unknown as { getContext: unknown }).getContext = makeCtx
+  ;(
+    dom.window.HTMLCanvasElement.prototype as unknown as { getContext: unknown }
+  ).getContext = makeCtx
 }
 
 export async function exportSvg({

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -126,23 +126,25 @@ async function main() {
   const command = positionals[0]
 
   if (command === 'export-svg') {
-    const msaFile = values['msa']
+    const msaFile = values.msa
     if (!msaFile) {
       console.error('Error: --msa <file> is required')
       process.exit(1)
     }
-    const outputFile = values.output === 'domains.gff' ? 'alignment.svg' : values.output!
+    const outputFile =
+      values.output === 'domains.gff' ? 'alignment.svg' : values.output
     await exportSvg({
       msaFile,
-      treeFile: values['tree'],
-      gffFile: values['gff'],
+      treeFile: values.tree,
+      gffFile: values.gff,
       outputFile,
-      colorScheme: values['color-scheme']!,
-      width: parseInt(values['width']!, 10),
-      height: parseInt(values['height']!, 10),
-      treeAreaWidth: values['tree-area-width'] !== undefined
-        ? parseInt(values['tree-area-width']!, 10)
-        : undefined,
+      colorScheme: values['color-scheme'],
+      width: parseInt(values.width, 10),
+      height: parseInt(values.height, 10),
+      treeAreaWidth:
+        values['tree-area-width'] !== undefined
+          ? parseInt(values['tree-area-width'], 10)
+          : undefined,
     })
     console.log(`wrote ${outputFile}`)
   } else if (command === 'interproscan') {

--- a/packages/examples/src/vite-env.d.ts
+++ b/packages/examples/src/vite-env.d.ts
@@ -1,8 +1,0 @@
-/// <reference types="vite/client" />
-
-// Fallback declarations for Vite's virtual ?raw imports, in case vite/client
-// fails to resolve in a given typecheck environment (CI hoisting differences).
-declare module '*?raw' {
-  const src: string
-  export default src
-}

--- a/packages/examples/src/vite-env.d.ts
+++ b/packages/examples/src/vite-env.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="vite/client" />
+
+// Fallback declarations for Vite's virtual ?raw imports, in case vite/client
+// fails to resolve in a given typecheck environment (CI hoisting differences).
+declare module '*?raw' {
+  const src: string
+  export default src
+}

--- a/packages/lib/apidocs/MsaView.md
+++ b/packages/lib/apidocs/MsaView.md
@@ -356,13 +356,14 @@ highlightedColumns: undefined as number[] | undefined
 #### volatile: highResScaleFactor
 
 high resolution scale factor, helps make canvas look better on hi-dpi
-screens
+screens. derived from the device pixel ratio so canvases are crisp on
+retina/4k displays and not needlessly oversized on standard ones
 
 ```js
 // type signature
 number
 // code
-highResScaleFactor: 2
+highResScaleFactor: typeof window === 'undefined' ? 1 : window.devicePixelRatio
 ```
 
 #### volatile: hoveredTreeNode
@@ -1242,6 +1243,16 @@ in-repo caller, so do not flag it as dead code — it is public API.
 ```js
 // type signature
 setHighlightedColumns: (columns?: number[] | undefined) => void
+```
+
+#### action: setHighResScaleFactor
+
+high-res scale factor, tracks the device pixel ratio so canvases stay
+crisp when the window moves between monitors or the browser zooms
+
+```js
+// type signature
+setHighResScaleFactor: (arg: number) => void
 ```
 
 #### action: setHoveredTreeNode

--- a/packages/lib/src/components/MSAView.tsx
+++ b/packages/lib/src/components/MSAView.tsx
@@ -1,7 +1,8 @@
-import React, { Suspense } from 'react'
+import React, { Suspense, useEffect } from 'react'
 
 import { observer } from 'mobx-react'
 
+import { useDevicePixelRatio } from '../useDevicePixelRatio.ts'
 import {
   HorizontalResizeHandle,
   VerticalResizeHandle,
@@ -128,6 +129,14 @@ const View = observer(function ({ model }: { model: MsaViewModel }) {
 
 const MSAView = observer(function ({ model }: { model: MsaViewModel }) {
   const { height, viewInitialized, DialogComponent, DialogProps } = model
+
+  // mirror the live device pixel ratio into the model so canvas backing stores
+  // re-scale when the window moves between monitors or the browser zooms
+  const devicePixelRatio = useDevicePixelRatio()
+  useEffect(() => {
+    model.setHighResScaleFactor(devicePixelRatio)
+  }, [model, devicePixelRatio])
+
   return (
     <div>
       {viewInitialized ? (

--- a/packages/lib/src/components/msa/MSAMouseoverCanvas.tsx
+++ b/packages/lib/src/components/msa/MSAMouseoverCanvas.tsx
@@ -14,7 +14,8 @@ const MSAMouseoverCanvas = observer(function ({
   model: MsaViewModel
 }) {
   const ref = useRef<HTMLCanvasElement>(null)
-  const { height, msaAreaWidth, verticalScrollbarWidth } = model
+  const { height, msaAreaWidth, verticalScrollbarWidth, highResScaleFactor } =
+    model
   const width = msaAreaWidth - verticalScrollbarWidth
   useEffect(() => {
     const ctx = ref.current?.getContext('2d')
@@ -31,8 +32,8 @@ const MSAMouseoverCanvas = observer(function ({
     <canvas
       ref={ref}
       id="mouseover"
-      width={width}
-      height={height}
+      width={width * highResScaleFactor}
+      height={height * highResScaleFactor}
       style={{
         position: 'absolute',
         top: 0,

--- a/packages/lib/src/components/msa/renderMSAMouseover.ts
+++ b/packages/lib/src/components/msa/renderMSAMouseover.ts
@@ -27,10 +27,12 @@ export function renderMouseover({
     relativeTo,
     hoveredTreeNode,
     highlightedColumns,
+    highResScaleFactor,
   } = model
   const width = msaAreaWidth - verticalScrollbarWidth
   ctx.resetTransform()
-  ctx.clearRect(0, 0, width, height)
+  ctx.clearRect(0, 0, width * highResScaleFactor, height * highResScaleFactor)
+  ctx.scale(highResScaleFactor, highResScaleFactor)
 
   // Highlight reference row (relativeTo) persistently
   if (relativeTo) {

--- a/packages/lib/src/flatToTree.test.ts
+++ b/packages/lib/src/flatToTree.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'vitest'
+
+import { flatToTree } from './flatToTree.ts'
+
+describe('flatToTree', () => {
+  test('builds a tree from a flat parent list', () => {
+    const root = flatToTree([
+      { id: 0 },
+      { id: 1, parent: 0 },
+      { id: 2, parent: 0 },
+      { id: 3, parent: 1 },
+    ])
+    expect(root.id).toBe('0')
+    expect(root.children.map(c => c.id)).toEqual(['1', '2'])
+    expect(root.children[0]!.children.map(c => c.id)).toEqual(['3'])
+  })
+
+  test('throws on empty input rather than returning undefined', () => {
+    expect(() => flatToTree([])).toThrow(/no root/)
+  })
+
+  test('throws when every node has a parent (cycle) rather than returning undefined', () => {
+    expect(() =>
+      flatToTree([
+        { id: 0, parent: 1 },
+        { id: 1, parent: 0 },
+      ]),
+    ).toThrow(/no root/)
+  })
+})

--- a/packages/lib/src/flatToTree.ts
+++ b/packages/lib/src/flatToTree.ts
@@ -35,5 +35,14 @@ export function flatToTree(items: FlatItem[]): TreeNode {
     }
   }
 
-  return root!
+  if (root === undefined) {
+    // no node lacks a (resolvable) parent: empty input, or every node's parent
+    // points back into the set (a cycle). returning undefined here would crash
+    // cryptically downstream, so fail with a diagnosable message instead
+    throw new Error(
+      'could not build tree from flat node list: no root found (input was empty or contains a parent cycle)',
+    )
+  }
+
+  return root
 }

--- a/packages/lib/src/hierarchy.test.ts
+++ b/packages/lib/src/hierarchy.test.ts
@@ -1,8 +1,35 @@
 import { describe, expect, test } from 'vitest'
 
-import { collapse, find, hierarchy, leaves, sort, sum } from './hierarchy.ts'
+import {
+  calcDepthToLeaf,
+  collapse,
+  find,
+  findMaxBranchLen,
+  hierarchy,
+  leaves,
+  maxLength,
+  setBrLength,
+  sort,
+  sum,
+} from './hierarchy.ts'
 
 import type { NodeWithIds } from './types.ts'
+
+// Builds a fully unbalanced "caterpillar" tree of the given depth: each internal
+// node has one leaf child and one internal child. Recursion over this would blow
+// the call stack; the iterative traversals must handle it.
+function makeDeepTree(depth: number): NodeWithIds {
+  let node: NodeWithIds = { id: 'leaf0', name: 'leaf0', children: [] }
+  for (let i = 1; i <= depth; i++) {
+    node = {
+      id: `node${i}`,
+      name: `node${i}`,
+      length: 1,
+      children: [{ id: `leaf${i}`, name: `leaf${i}`, children: [] }, node],
+    }
+  }
+  return node
+}
 
 function makeTree(): NodeWithIds {
   return {
@@ -116,5 +143,30 @@ describe('sum', () => {
     sum(h, d => (d.children.length > 0 ? 0 : 1))
     expect(h.value).toBe(4)
     expect(find(h, n => n.data.id === 'A')?.value).toBe(2)
+  })
+})
+
+describe('deep (caterpillar) trees do not overflow the stack', () => {
+  const depth = 100_000
+
+  test('build, height, leaf count, and ordering', () => {
+    const h = hierarchy(makeDeepTree(depth), d => d.children)
+    expect(h.height).toBe(depth)
+    const l = leaves(h)
+    expect(l.length).toBe(depth + 1)
+    // each level contributes its own leafN before descending; deepest leaf last
+    expect(l[0]!.data.name).toBe(`leaf${depth}`)
+    expect(l.at(-1)!.data.name).toBe('leaf0')
+  })
+
+  test('accumulation helpers (sum, find, maxLength, setBrLength, depth)', () => {
+    const h = hierarchy(makeDeepTree(depth), d => d.children)
+    sum(h, d => (d.children.length > 0 ? 0 : 1))
+    expect(h.value).toBe(depth + 1)
+    expect(find(h, n => n.data.id === 'leaf0')?.data.name).toBe('leaf0')
+    expect(maxLength(h)).toBe(depth)
+    expect(calcDepthToLeaf(h)).toBe(depth)
+    setBrLength(h, 0, 1)
+    expect(findMaxBranchLen(h)).toBe(depth)
   })
 })

--- a/packages/lib/src/hierarchy.ts
+++ b/packages/lib/src/hierarchy.ts
@@ -19,45 +19,72 @@ export interface HierarchyLink<T = NodeWithIds> {
   target: HierarchyNode<T>
 }
 
-function computeHeight<T>(node: HierarchyNode<T>): number {
-  let h = 0
-  if (node.children) {
-    for (const child of node.children) {
-      const ch = computeHeight(child) + 1
-      if (ch > h) {
-        h = ch
+// All traversals below are iterative (explicit stack / reversed-preorder) rather
+// than recursive: phylogenetic trees can be deeply unbalanced (a caterpillar tree
+// has depth ~= leaf count), which overflows the JS call stack on recursion.
+
+// Pre-order: every parent precedes all of its descendants. Iterating the result
+// in reverse therefore yields a valid post-order (children before parents), which
+// the accumulation helpers rely on.
+export function descendants<T>(node: HierarchyNode<T>): HierarchyNode<T>[] {
+  const result: HierarchyNode<T>[] = []
+  const stack = [node]
+  while (stack.length > 0) {
+    const n = stack.pop()!
+    result.push(n)
+    if (n.children) {
+      for (let i = n.children.length - 1; i >= 0; i--) {
+        stack.push(n.children[i]!)
       }
     }
   }
-  node.height = h
-  return h
+  return result
 }
 
-function wrap<T>(
-  data: T,
-  childrenAccessor: (d: T) => T[] | undefined,
-  parent: HierarchyNode<T> | null,
-  depth: number,
-): HierarchyNode<T> {
-  const kids = childrenAccessor(data)
-  const node: HierarchyNode<T> = {
-    data,
-    children: null,
-    parent,
-    depth,
-    height: 0,
+function computeHeight<T>(node: HierarchyNode<T>) {
+  const nodes = descendants(node)
+  for (let i = nodes.length - 1; i >= 0; i--) {
+    const n = nodes[i]!
+    let h = 0
+    if (n.children) {
+      for (const child of n.children) {
+        if (child.height + 1 > h) {
+          h = child.height + 1
+        }
+      }
+    }
+    n.height = h
   }
-  if (kids?.length) {
-    node.children = kids.map(d => wrap(d, childrenAccessor, node, depth + 1))
-  }
-  return node
 }
 
 export function hierarchy<T>(
   data: T,
   childrenAccessor: (d: T) => T[] | undefined,
 ): HierarchyNode<T> {
-  const root = wrap(data, childrenAccessor, null, 0)
+  const root: HierarchyNode<T> = {
+    data,
+    children: null,
+    parent: null,
+    depth: 0,
+    height: 0,
+  }
+  const stack = [root]
+  while (stack.length > 0) {
+    const node = stack.pop()!
+    const kids = childrenAccessor(node.data)
+    if (kids?.length) {
+      node.children = kids.map(d => ({
+        data: d,
+        children: null,
+        parent: node,
+        depth: node.depth + 1,
+        height: 0,
+      }))
+      for (const child of node.children) {
+        stack.push(child)
+      }
+    }
+  }
   computeHeight(root)
   return root
 }
@@ -66,17 +93,17 @@ export function sum<T>(
   node: HierarchyNode<T>,
   valueFn: (d: T) => number,
 ): HierarchyNode<T> {
-  function visit(n: HierarchyNode<T>): number {
+  const nodes = descendants(node)
+  for (let i = nodes.length - 1; i >= 0; i--) {
+    const n = nodes[i]!
     let s = valueFn(n.data)
     if (n.children) {
       for (const child of n.children) {
-        s += visit(child)
+        s += child.value!
       }
     }
     n.value = s
-    return s
   }
-  visit(node)
   return node
 }
 
@@ -84,15 +111,16 @@ export function sort<T>(
   node: HierarchyNode<T>,
   compareFn: (a: HierarchyNode<T>, b: HierarchyNode<T>) => number,
 ): HierarchyNode<T> {
-  function visit(n: HierarchyNode<T>) {
+  const stack = [node]
+  while (stack.length > 0) {
+    const n = stack.pop()!
     if (n.children) {
       n.children.sort(compareFn)
       for (const child of n.children) {
-        visit(child)
+        stack.push(child)
       }
     }
   }
-  visit(node)
   return node
 }
 
@@ -100,60 +128,42 @@ export function find<T>(
   node: HierarchyNode<T>,
   predicate: (n: HierarchyNode<T>) => boolean,
 ): HierarchyNode<T> | undefined {
-  if (predicate(node)) {
-    return node
-  }
-  if (node.children) {
-    for (const child of node.children) {
-      const result = find(child, predicate)
-      if (result) {
-        return result
+  const stack = [node]
+  let found: HierarchyNode<T> | undefined
+  while (stack.length > 0 && found === undefined) {
+    const n = stack.pop()!
+    if (predicate(n)) {
+      found = n
+    } else if (n.children) {
+      for (let i = n.children.length - 1; i >= 0; i--) {
+        stack.push(n.children[i]!)
       }
     }
   }
-  return undefined
+  return found
 }
 
 export function leaves<T>(node: HierarchyNode<T>): HierarchyNode<T>[] {
   const result: HierarchyNode<T>[] = []
-  function visit(n: HierarchyNode<T>) {
+  const stack = [node]
+  while (stack.length > 0) {
+    const n = stack.pop()!
     if (n.children) {
-      for (const child of n.children) {
-        visit(child)
+      for (let i = n.children.length - 1; i >= 0; i--) {
+        stack.push(n.children[i]!)
       }
     } else {
       result.push(n)
     }
   }
-  visit(node)
-  return result
-}
-
-export function descendants<T>(node: HierarchyNode<T>): HierarchyNode<T>[] {
-  const result: HierarchyNode<T>[] = []
-  function visit(n: HierarchyNode<T>) {
-    result.push(n)
-    if (n.children) {
-      for (const child of n.children) {
-        visit(child)
-      }
-    }
-  }
-  visit(node)
   return result
 }
 
 export function links<T>(node: HierarchyNode<T>): HierarchyLink<T>[] {
   const result: HierarchyLink<T>[] = []
-  function visit(n: HierarchyNode<T>) {
-    if (n.children) {
-      for (const child of n.children) {
-        result.push({ source: n, target: child })
-        visit(child)
-      }
-    }
-  }
-  visit(node)
+  forEachLink(node, (source, target) => {
+    result.push({ source, target })
+  })
   return result
 }
 
@@ -161,26 +171,25 @@ export function forEachLink<T>(
   node: HierarchyNode<T>,
   cb: (source: HierarchyNode<T>, target: HierarchyNode<T>) => void,
 ) {
-  function visit(n: HierarchyNode<T>) {
+  const stack = [node]
+  while (stack.length > 0) {
+    const n = stack.pop()!
     if (n.children) {
-      for (const child of n.children) {
+      for (let i = n.children.length - 1; i >= 0; i--) {
+        const child = n.children[i]!
         cb(n, child)
-        visit(child)
+        stack.push(child)
       }
     }
   }
-  visit(node)
 }
 
 export function forEachDescendant<T>(
   node: HierarchyNode<T>,
   cb: (n: HierarchyNode<T>) => void,
 ) {
-  cb(node)
-  if (node.children) {
-    for (const child of node.children) {
-      forEachDescendant(child, cb)
-    }
+  for (const n of descendants(node)) {
+    cb(n)
   }
 }
 
@@ -197,31 +206,31 @@ export function clusterLayout<T>(
     leafNodes[i]!.x = (i + 0.5) * step
   }
 
-  function assignX(node: HierarchyNode<T>) {
-    if (!node.children) {
-      return
+  // x of an internal node is the mean of its children's x, so process in
+  // post-order (children before parents)
+  const nodes = descendants(root)
+  for (let i = nodes.length - 1; i >= 0; i--) {
+    const node = nodes[i]!
+    if (node.children) {
+      let sum = 0
+      for (const child of node.children) {
+        sum += child.x!
+      }
+      node.x = sum / node.children.length
     }
-    for (const child of node.children) {
-      assignX(child)
-    }
-    let sum = 0
-    for (const child of node.children) {
-      sum += child.x!
-    }
-    node.x = sum / node.children.length
   }
-  assignX(root)
 
   const rootHeight = root.height
-  function assignY(node: HierarchyNode<T>, depth: number) {
+  const stack = [{ node: root, depth: 0 }]
+  while (stack.length > 0) {
+    const { node, depth } = stack.pop()!
     node.y = rootHeight === 0 ? sizeY : (depth / rootHeight) * sizeY
     if (node.children) {
       for (const child of node.children) {
-        assignY(child, depth + 1)
+        stack.push({ node: child, depth: depth + 1 })
       }
     }
   }
-  assignY(root, 0)
 }
 
 export function collapse<T>(node: HierarchyNode<T>) {
@@ -236,40 +245,57 @@ export function collapse<T>(node: HierarchyNode<T>) {
 // x. Memoizes onto node.depthToLeaf since the layout walks the tree repeatedly.
 // See https://github.com/emmanuelparadis/ape/blob/master/R/plot.phylo.R
 export function calcDepthToLeaf(node: HierarchyNode): number {
-  if (node.depthToLeaf === undefined) {
-    let maxDepth = 0
-    if (node.children) {
-      for (const child of node.children) {
-        maxDepth = Math.max(maxDepth, 1 + calcDepthToLeaf(child))
+  const nodes = descendants(node)
+  for (let i = nodes.length - 1; i >= 0; i--) {
+    const n = nodes[i]!
+    if (n.depthToLeaf === undefined) {
+      let maxDepth = 0
+      if (n.children) {
+        for (const child of n.children) {
+          maxDepth = Math.max(maxDepth, 1 + child.depthToLeaf!)
+        }
       }
+      n.depthToLeaf = maxDepth
     }
-    node.depthToLeaf = maxDepth
   }
-  return node.depthToLeaf
+  return node.depthToLeaf!
 }
 
 export function findMaxBranchLen(node: HierarchyNode): number {
-  let maxLen = node.len || 0
-  if (node.children) {
-    for (const child of node.children) {
-      maxLen = Math.max(maxLen, findMaxBranchLen(child))
-    }
+  let maxLen = 0
+  for (const n of descendants(node)) {
+    maxLen = Math.max(maxLen, n.len || 0)
   }
   return maxLen
 }
 
+// Max root-to-leaf sum of branch lengths within the subtree at d
 export function maxLength(d: HierarchyNode): number {
-  return (
-    (d.data.length || 0) +
-    (d.children ? d.children.reduce((m, c) => Math.max(m, maxLength(c)), 0) : 0)
-  )
+  const nodes = descendants(d)
+  const pathLen = new Map<HierarchyNode, number>()
+  for (let i = nodes.length - 1; i >= 0; i--) {
+    const n = nodes[i]!
+    let childMax = 0
+    if (n.children) {
+      for (const child of n.children) {
+        childMax = Math.max(childMax, pathLen.get(child)!)
+      }
+    }
+    pathLen.set(n, (n.data.length || 0) + childMax)
+  }
+  return pathLen.get(d)!
 }
 
 export function setBrLength(d: HierarchyNode, y0: number, k: number) {
-  d.len = (y0 += Math.max(d.data.length || 0, 0)) * k
-  if (d.children) {
-    for (const child of d.children) {
-      setBrLength(child, y0, k)
+  const stack = [{ node: d, y0 }]
+  while (stack.length > 0) {
+    const { node, y0: acc } = stack.pop()!
+    const next = acc + Math.max(node.data.length || 0, 0)
+    node.len = next * k
+    if (node.children) {
+      for (const child of node.children) {
+        stack.push({ node: child, y0: next })
+      }
     }
   }
 }

--- a/packages/lib/src/launchInterProScan.ts
+++ b/packages/lib/src/launchInterProScan.ts
@@ -93,7 +93,9 @@ async function wait({
         status === 'ERROR' ||
         status === 'NOT_FOUND'
       ) {
-        throw new Error(`InterProScan job ${jobId} ended with status: ${status}`)
+        throw new Error(
+          `InterProScan job ${jobId} ended with status: ${status}`,
+        )
       }
     }
     if (!finished) {
@@ -171,7 +173,9 @@ async function loadInterProScanResultsWithStatus({
       Object.fromEntries(
         ret.results
           .map(r => [r.xref[0]?.id, r] as const)
-          .filter((e): e is [string, InterProScanResults] => e[0] !== undefined),
+          .filter(
+            (e): e is [string, InterProScanResults] => e[0] !== undefined,
+          ),
       ),
     )
     getSession(model).notify(`Loaded interproscan ${jobId} results`, 'success')

--- a/packages/lib/src/launchInterProScan.ts
+++ b/packages/lib/src/launchInterProScan.ts
@@ -73,20 +73,33 @@ async function wait({
   signal?: AbortSignal
 }) {
   const url = `${base}/iprscan5/status/${jobId}`
+  // EBI jobs run for minutes; cap polling so an unexpected/stuck status can't
+  // spin forever (the abort signal is the normal early exit). ~10s per check.
+  const maxChecks = 360
   try {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    while (true) {
+    let finished = false
+    for (let check = 0; check < maxChecks && !finished; check++) {
       for (let i = 0; i < 10; i++) {
         await timeout(1000, signal)
         onProgress({ msg: `Checking status ${10 - i}`, url })
       }
-      const result = await textfetch(url, { signal })
-      if (result.includes('FINISHED')) {
-        break
+      // status endpoint returns a bare status token; match exactly rather than
+      // substring so an error page mentioning "FINISHED" can't be a false hit
+      const status = (await textfetch(url, { signal })).trim()
+      if (status === 'FINISHED') {
+        finished = true
+      } else if (
+        status === 'FAILURE' ||
+        status === 'ERROR' ||
+        status === 'NOT_FOUND'
+      ) {
+        throw new Error(`InterProScan job ${jobId} ended with status: ${status}`)
       }
-      if (result.includes('FAILURE')) {
-        throw new Error(`Failed to run: jobId ${jobId}`)
-      }
+    }
+    if (!finished) {
+      throw new Error(
+        `InterProScan job ${jobId} did not finish after ${maxChecks} status checks`,
+      )
     }
   } finally {
     onProgress()
@@ -152,8 +165,14 @@ async function loadInterProScanResultsWithStatus({
       url: `https://www.ebi.ac.uk/Tools/services/rest/iprscan5/result/${jobId}/json`,
     })
     const ret = await loadInterProScanResults(jobId, signal)
+    // key each result by its xref id; skip any result lacking an xref entry
+    // rather than crashing the whole load on one malformed result
     model.setDomains(
-      Object.fromEntries(ret.results.map(r => [r.xref[0]!.id, r])),
+      Object.fromEntries(
+        ret.results
+          .map(r => [r.xref[0]?.id, r] as const)
+          .filter((e): e is [string, InterProScanResults] => e[0] !== undefined),
+      ),
     )
     getSession(model).notify(`Loaded interproscan ${jobId} results`, 'success')
   } catch (e) {

--- a/packages/lib/src/model.ts
+++ b/packages/lib/src/model.ts
@@ -268,9 +268,11 @@ function stateModelFactory() {
       /**
        * #volatile
        * high resolution scale factor, helps make canvas look better on hi-dpi
-       * screens
+       * screens. derived from the device pixel ratio so canvases are crisp on
+       * retina/4k displays and not needlessly oversized on standard ones
        */
-      highResScaleFactor: 2,
+      highResScaleFactor:
+        typeof window === 'undefined' ? 1 : window.devicePixelRatio,
 
       /**
        * #volatile
@@ -398,6 +400,14 @@ function stateModelFactory() {
        */
       setWidth(arg: number) {
         self.volatileWidth = arg
+      },
+      /**
+       * #action
+       * high-res scale factor, tracks the device pixel ratio so canvases stay
+       * crisp when the window moves between monitors or the browser zooms
+       */
+      setHighResScaleFactor(arg: number) {
+        self.highResScaleFactor = arg
       },
       /**
        * #action
@@ -1737,26 +1747,39 @@ function stateModelFactory() {
           }),
         )
 
-        // autorun opens treeFilehandle
+        // autorun opens treeFilehandle. generation guard: if the filehandle
+        // changes mid-fetch, a slower earlier request must not clobber the data
+        // (or loading flag) set by the newer one
+        let treeGeneration = 0
         addDisposer(
           self,
           autorun(async () => {
             const { treeFilehandle } = self
             if (treeFilehandle) {
+              const generation = ++treeGeneration
               try {
                 self.setLoadingTree(true)
-                self.setTree(
-                  await fetchAndMaybeUnzipText(openLocation(treeFilehandle)),
+                const text = await fetchAndMaybeUnzipText(
+                  openLocation(treeFilehandle),
                 )
-                if (treeFilehandle.locationType === 'BlobLocation') {
-                  // clear filehandle after loading if from a local file
-                  self.setTreeFilehandle(undefined)
+                if (generation === treeGeneration) {
+                  transaction(() => {
+                    self.setTree(text)
+                    if (treeFilehandle.locationType === 'BlobLocation') {
+                      // clear filehandle after loading if from a local file
+                      self.setTreeFilehandle(undefined)
+                    }
+                  })
                 }
               } catch (e) {
-                console.error(e)
-                self.setError(e)
+                if (generation === treeGeneration) {
+                  console.error(e)
+                  self.setError(e)
+                }
               } finally {
-                self.setLoadingTree(false)
+                if (generation === treeGeneration) {
+                  self.setLoadingTree(false)
+                }
               }
             }
           }),
@@ -1819,30 +1842,38 @@ function stateModelFactory() {
           }),
         )
 
-        // autorun opens msaFilehandle
+        // autorun opens msaFilehandle. generation guard: see treeFilehandle
+        let msaGeneration = 0
         addDisposer(
           self,
           autorun(async () => {
             const { msaFilehandle } = self
             if (msaFilehandle) {
+              const generation = ++msaGeneration
               try {
                 self.setLoadingMSA(true)
                 self.setError(undefined)
                 const txt = await fetchAndMaybeUnzipText(
                   openLocation(msaFilehandle),
                 )
-                transaction(() => {
-                  self.setMSA(txt)
-                  if (msaFilehandle.locationType === 'BlobLocation') {
-                    // clear filehandle after loading if from a local file
-                    self.setMSAFilehandle(undefined)
-                  }
-                })
+                if (generation === msaGeneration) {
+                  transaction(() => {
+                    self.setMSA(txt)
+                    if (msaFilehandle.locationType === 'BlobLocation') {
+                      // clear filehandle after loading if from a local file
+                      self.setMSAFilehandle(undefined)
+                    }
+                  })
+                }
               } catch (e) {
-                console.error(e)
-                self.setError(e)
+                if (generation === msaGeneration) {
+                  console.error(e)
+                  self.setError(e)
+                }
               } finally {
-                self.setLoadingMSA(false)
+                if (generation === msaGeneration) {
+                  self.setLoadingMSA(false)
+                }
               }
             }
           }),

--- a/packages/lib/src/parseAsn1.test.ts
+++ b/packages/lib/src/parseAsn1.test.ts
@@ -12,3 +12,9 @@ const r = readFileSync(
 test('real data file', () => {
   expect(parseAsn1(r)).toMatchSnapshot()
 })
+
+test('throws a clear error on input missing required sections', () => {
+  expect(() => parseAsn1('BioTreeContainer ::= { something {} }')).toThrow(
+    /missing/,
+  )
+})

--- a/packages/lib/src/parseAsn1.ts
+++ b/packages/lib/src/parseAsn1.ts
@@ -88,15 +88,23 @@ export function parseAsn1(
     .replace(/^.*?::=/, '')
 
   const sections = extractSections(normalized)
+  const { fdict, nodes } = sections
+  if (fdict === undefined || nodes === undefined) {
+    // a truncated/malformed BioTreeContainer would otherwise pass undefined to
+    // extractBracedBlocks and crash cryptically; fail with a clear message
+    throw new Error(
+      `invalid BioTreeContainer ASN.1: missing '${fdict === undefined ? 'fdict' : 'nodes'}' section`,
+    )
+  }
 
   const dict = Object.fromEntries(
-    extractBracedBlocks(sections.fdict!).flatMap(block => {
+    extractBracedBlocks(fdict).flatMap(block => {
       const entry = parseDictEntry(block)
       return entry ? [[entry.id, remap[entry.name] || entry.name]] : []
     }),
   )
 
-  return extractBracedBlocks(sections.nodes!).flatMap(block => {
+  return extractBracedBlocks(nodes).flatMap(block => {
     const node = parseNode(block)
     if (!node) {
       return []

--- a/packages/lib/src/renderToSvg.tsx
+++ b/packages/lib/src/renderToSvg.tsx
@@ -23,9 +23,19 @@ export interface ExportSvgOptions {
 }
 export async function renderToSvg(model: MsaViewModel, opts: ExportSvgOptions) {
   await when(() => model.dataInitialized)
-  const { width, height, scrollX, scrollY, totalTrackAreaHeight } = model
-  const { exportType, theme, includeMinimap, includeTracks } = opts
+  const {
+    width,
+    height,
+    scrollX,
+    scrollY,
+    totalTrackAreaHeight,
+    minimapHeight,
+  } = model
+  const { exportType, theme, includeTracks } = opts
   const trackHeight = includeTracks ? totalTrackAreaHeight : 0
+  // the minimap reflects the live viewport scroll position, so it's only
+  // meaningful for a viewport export, never for the entire alignment
+  const includeMinimap = exportType === 'viewport' && !!opts.includeMinimap
 
   if (exportType === 'entire') {
     return render({
@@ -43,7 +53,7 @@ export async function renderToSvg(model: MsaViewModel, opts: ExportSvgOptions) {
   }
   return render({
     width,
-    height: height + (includeMinimap ? model.minimapHeight : 0) + trackHeight,
+    height: height + (includeMinimap ? minimapHeight : 0) + trackHeight,
     contentHeight: height,
     trackHeight,
     theme,
@@ -79,37 +89,48 @@ async function render({
   includeTracks?: boolean
 }) {
   const { Context } = await import('@jbrowse/svgcanvas')
-  const Wrapper = includeMinimap ? MinimapWrapper : NullWrapper
+  const { treeAreaWidth, minimapHeight } = model
+
+  const content = (
+    <>
+      {includeTracks && trackHeight > 0 ? (
+        <TrackRendering
+          Context={Context}
+          model={model}
+          theme={theme}
+          offsetX={offsetX}
+          msaAreaWidth={width - treeAreaWidth}
+          trackHeight={trackHeight}
+        />
+      ) : null}
+      <g
+        transform={trackHeight > 0 ? `translate(0 ${trackHeight})` : undefined}
+      >
+        <CoreRendering
+          Context={Context}
+          model={model}
+          theme={theme}
+          offsetX={offsetX}
+          offsetY={offsetY}
+          msaAreaWidth={width - treeAreaWidth}
+          contentHeight={contentHeight}
+        />
+      </g>
+    </>
+  )
 
   return renderToStaticMarkup(
     <SvgWrapper width={width} height={height}>
-      <Wrapper model={model}>
-        {includeTracks && trackHeight > 0 ? (
-          <TrackRendering
-            Context={Context}
-            model={model}
-            theme={theme}
-            offsetX={offsetX}
-            msaAreaWidth={width - model.treeAreaWidth}
-            trackHeight={trackHeight}
-          />
-        ) : null}
-        <g
-          transform={
-            trackHeight > 0 ? `translate(0 ${trackHeight})` : undefined
-          }
-        >
-          <CoreRendering
-            Context={Context}
-            model={model}
-            theme={theme}
-            offsetX={offsetX}
-            offsetY={offsetY}
-            msaAreaWidth={width - model.treeAreaWidth}
-            contentHeight={contentHeight}
-          />
-        </g>
-      </Wrapper>
+      {includeMinimap ? (
+        <>
+          <g transform={`translate(${treeAreaWidth} 0)`}>
+            <MinimapSVG model={model} />
+          </g>
+          <g transform={`translate(0 ${minimapHeight})`}>{content}</g>
+        </>
+      ) : (
+        content
+      )}
     </SvgWrapper>,
   )
 }
@@ -176,16 +197,33 @@ function CoreRendering({
         </clipPath>
       </defs>
 
-      <g
-        clipPath={`url(#${clipId1})`}
-        dangerouslySetInnerHTML={{ __html: ctx1.getSvg().innerHTML }}
-      />
-      <g
-        clipPath={`url(#${clipId2})`}
+      <ClipGroup clipId={clipId1} html={ctx1.getSvg().innerHTML} />
+      <ClipGroup
+        clipId={clipId2}
         transform={`translate(${treeAreaWidth} 0)`}
-        dangerouslySetInnerHTML={{ __html: ctx2.getSvg().innerHTML }}
+        html={ctx2.getSvg().innerHTML}
       />
     </>
+  )
+}
+
+// Wraps SVG markup produced by a svgcanvas Context in a clipped group. The
+// markup is injected verbatim since it's already serialized SVG, not React.
+function ClipGroup({
+  clipId,
+  html,
+  transform,
+}: {
+  clipId: string
+  html: string
+  transform?: string
+}) {
+  return (
+    <g
+      clipPath={`url(#${clipId})`}
+      transform={transform}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
   )
 }
 
@@ -226,31 +264,8 @@ function TrackRendering({
           <rect x={0} y={0} width={msaAreaWidth} height={trackHeight} />
         </clipPath>
       </defs>
-      <g
-        clipPath={`url(#${clipId})`}
-        dangerouslySetInnerHTML={{ __html: ctx.getSvg().innerHTML }}
-      />
+      <ClipGroup clipId={clipId} html={ctx.getSvg().innerHTML} />
     </g>
-  )
-}
-
-function MinimapWrapper({
-  model,
-  children,
-}: {
-  model: MsaViewModel
-  children: React.ReactNode
-}) {
-  const { minimapHeight, treeAreaWidth } = model
-
-  return (
-    <>
-      <g transform={`translate(${treeAreaWidth} 0)`}>
-        <MinimapSVG model={model} />
-      </g>
-
-      <g transform={`translate(0 ${minimapHeight})`}>{children}</g>
-    </>
   )
 }
 
@@ -275,8 +290,4 @@ function SvgWrapper({
       {children}
     </svg>
   )
-}
-
-function NullWrapper({ children }: { children: React.ReactNode }) {
-  return children
 }

--- a/packages/lib/src/useDevicePixelRatio.ts
+++ b/packages/lib/src/useDevicePixelRatio.ts
@@ -1,0 +1,29 @@
+import { useSyncExternalStore } from 'react'
+
+// Subscribes to devicePixelRatio changes (moving the window between monitors,
+// browser zoom). The matchMedia query is pinned to the current ratio, so on each
+// change we re-register against the new ratio to keep tracking subsequent moves.
+function subscribe(callback: () => void) {
+  if (typeof window === 'undefined') {
+    return () => {}
+  }
+  let mql = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`)
+  function onChange() {
+    callback()
+    mql.removeEventListener('change', onChange)
+    mql = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`)
+    mql.addEventListener('change', onChange)
+  }
+  mql.addEventListener('change', onChange)
+  return () => {
+    mql.removeEventListener('change', onChange)
+  }
+}
+
+function getSnapshot() {
+  return typeof window === 'undefined' ? 1 : window.devicePixelRatio
+}
+
+export function useDevicePixelRatio() {
+  return useSyncExternalStore(subscribe, getSnapshot, () => 1)
+}

--- a/packages/msa-parsers/src/msa/ClustalMSA.ts
+++ b/packages/msa-parsers/src/msa/ClustalMSA.ts
@@ -19,7 +19,9 @@ export default class ClustalMSA extends BaseMSA {
   }
 
   getWidth() {
-    return this.MSA.alns[0]!.seq.length
+    // 0 for an empty alignment (e.g. unrecognized text routed here as fallback)
+    // rather than crashing on alns[0]
+    return this.MSA.alns[0]?.seq.length ?? 0
   }
 
   getHeader() {

--- a/packages/msa-parsers/src/msa/EmfMSA.ts
+++ b/packages/msa-parsers/src/msa/EmfMSA.ts
@@ -19,7 +19,8 @@ export default class EmfMSA extends BaseMSA {
   }
 
   getWidth() {
-    return this.MSA[0]!.seq.length
+    // 0 for an empty alignment rather than crashing on MSA[0]
+    return this.MSA[0]?.seq.length ?? 0
   }
 
   getNames() {


### PR DESCRIPTION
## Summary

Two related rounds of hardening/cleanup on the same branch:

**Harden rendering, tree traversal, and parsing against scaling and malformed input** (`a92c569`)
- **devicePixelRatio**: derive `highResScaleFactor` from `window.devicePixelRatio` (was hardcoded 2), tracked reactively so canvases re-scale on monitor change / browser zoom; fix the mouseover overlay that alone drew at 1x
- **async loads**: generation guards on the MSA/tree file-load autoruns so a slow earlier fetch can't clobber a newer request's state
- **hierarchy.ts**: convert tree traversals from recursion to iterative so deeply unbalanced caterpillar trees no longer overflow the JS stack (+ depth-100k regression test)
- **flatToTree / parseAsn1 / launchInterProScan / ClustalMSA / EmfMSA**: clear errors instead of cryptic crashes on empty/cyclic/malformed input

**Simplify SVG export wrappers and guard minimap in entire-mode export** (`f6a8b5f`)
- Force the minimap off for entire-alignment exports — it renders from the live viewport scroll position and the entire-mode height reserves no space for it, so it would overlap the alignment
- Replace the `MinimapWrapper`/`NullWrapper` indirection (`NullWrapper` was passed an undeclared `model` prop) with an inline conditional
- Extract a `ClipGroup` helper for the repeated clipped `dangerouslySetInnerHTML` group

## Test plan
- `tsc --noEmit` clean on the lib package
- `eslint` clean
- `pnpm figures` regenerates byte-identical SVG output (the export refactor is behavior-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)